### PR TITLE
CI(testing): Resolve zizmor security findings

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Perform setup prior to running test(s)
       - name: "Checkout sample project repository"
@@ -38,6 +40,7 @@ jobs:
         with:
           repository: "lfreleng-actions/test-python-project"
           path: "test-python-project"
+          persist-credentials: false
 
       - name: "Extract project name from pyproject.toml"
         id: test-grep
@@ -85,12 +88,14 @@ jobs:
 
       - name: "Validate action output: ${{ github.repository }}"
         shell: bash
+        env:
+          EXTRACTED_STRING: "${{ steps.test-grep.outputs.extracted_string }}"
         run: |
           # Validate Action Output
-          if [ "${{ steps.test-grep.outputs.extracted_string }}" \
+          if [ "$EXTRACTED_STRING" \
             != "lfreleng-test-python-project" ]; then
             echo "Unexpected return value for: test-python-project ❌"
-            echo "Returned: ${{ steps.test-grep.outputs.extracted_string }}"
+            echo "Returned: $EXTRACTED_STRING"
             echo "Expected: lfreleng-test-python-project"
             echo "Test failed ❌"
             exit 1


### PR DESCRIPTION
## Summary

Resolves all [zizmor](https://docs.zizmor.sh/) static-analysis findings
in the test workflow (`.github/workflows/testing.yaml`).

A full `zizmor .` scan now reports **no findings** (4 suppressed by
zizmor defaults), down from 4 actionable findings.

## Findings addressed

| Rule | Severity | Fix |
| --- | --- | --- |
| `artipacked` | Low | Set `persist-credentials: false` on both `actions/checkout` steps so the `GITHUB_TOKEN` is not persisted in the local git config and cannot leak through build artifacts |
| `template-injection` | Informational | Pass the action output through an `env:` variable (`EXTRACTED_STRING`) instead of expanding the `steps.*.outputs.*` context directly inside the `run:` block |

## Validation

- `zizmor .` → `No findings to report. Good job! (4 suppressed)`
- pre-commit hooks (yamllint, actionlint, workflow validation) pass

No behavioural change to the test logic; only the way untrusted values
reach the shell has been hardened.
